### PR TITLE
Fix pagination for getPagePosts

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,6 @@
 			"Buffer\\Facebook\\": "Facebook/"
 		}
 	},
-	"version": "1.1.0",
+	"version": "1.1.1",
 	"minimum-stability": "dev"
 }

--- a/tests/mocks/GraphNode.php
+++ b/tests/mocks/GraphNode.php
@@ -1,0 +1,16 @@
+<?php
+
+class GraphNode
+{
+    private $fields;
+
+    public function __construct($fields)
+    {
+        $this->fields = $fields;
+    }
+
+    public function getField($field)
+    {
+        return $this->fields[$field];
+    }
+}


### PR DESCRIPTION
Use `getGraphEdge` and `next` to navigate through the API results and get the results for all pages for the specified date range.

Bump version to 1.1.1