### PR TITLE
Add optional period parameter to getPageInsightsMetricsData

### DIFF
--- a/Facebook/Facebook.php
+++ b/Facebook/Facebook.php
@@ -44,7 +44,7 @@ class Facebook
     /*
      * Get page insights data for the given page, metrics and range.
      */
-    public function getPageInsightsMetricsData($pageId, $insightsMetrics, $since, $until)
+    public function getPageInsightsMetricsData($pageId, $insightsMetrics, $since, $until, $period = null)
     {
         $params = [
             "metric" => $insightsMetrics,
@@ -54,6 +54,11 @@ class Facebook
             $params["since"] = $since;
             $params["until"] = $until;
         }
+
+        if (!is_null($period)) {
+            $params["period"] = $period;
+        }
+
         $response = $this->sendRequest("GET", "/{$pageId}/insights", $params);
 
         if (!empty($response)) {

--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,6 @@
 			"Buffer\\Facebook\\": "Facebook/"
 		}
 	},
-	"version": "1.2.0",
+	"version": "1.2.1",
 	"minimum-stability": "dev"
 }

--- a/tests/FacebookTest.php
+++ b/tests/FacebookTest.php
@@ -182,6 +182,41 @@ class FacebookTest extends PHPUnit_Framework_TestCase
         $this->assertEquals($insightsData, []);
     }
 
+    public function testGetPageInsightsMetricsDataShouldAcceptAnOptionalPeriodParameter()
+    {
+        $facebook = new Facebook();
+        $responseMock = m::mock('\Facebook\FacebookResponse')
+            ->shouldReceive('getDecodedBody')
+            ->once()
+            ->andReturn([])
+            ->getMock();
+        $facebookMock = m::mock('\Facebook\Facebook');
+        $since  = "1493826552";
+        $until = "1496418552";
+        $period = 'day';
+        $params = [
+            "metric" => ['page_posts_impressions_unique'],
+            "until" => $until,
+            "since" => $since,
+            "period" => $period,
+        ];
+        $expectedGetParams = ["GET", "/2222222/insights", $params];
+
+        $facebookMock->shouldReceive('sendRequest')
+            ->withArgs($expectedGetParams)
+            ->once()
+            ->andReturn($responseMock);
+        $facebook->setFacebookLibrary($facebookMock);
+
+        $facebook->getPageInsightsMetricsData(
+            self::FB_PAGE_ID,
+            ['page_posts_impressions_unique'],
+            $since,
+            $until,
+            $period
+        );
+    }
+
     public function testGetPageInsightsMetricsDataShouldUseRightSinceAndUntil()
     {
         $decodedInsightsResponseData = [


### PR DESCRIPTION
This is required for IG page insights as no default exist.