### PR TITLE
Add a new method to get page access token

### DIFF
--- a/Facebook/Facebook.php
+++ b/Facebook/Facebook.php
@@ -42,6 +42,24 @@ class Facebook
     }
 
     /*
+     * Get page access token.
+     */
+    public function getPageAccessToken($pageId)
+    {
+
+        $response = $this->sendRequest("GET", "/{$pageId}", [
+            "fields" => "access_token",
+        ]);
+
+        if (empty($response) || $response->isError()) {
+            return null;
+        }
+        $data = $response->getDecodedBody();
+
+        return $data["access_token"] ?? null;
+    }
+
+    /*
      * Get page insights data for the given page, metrics and range.
      */
     public function getPageInsightsMetricsData($pageId, $insightsMetrics, $since, $until, $period = null)

--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,6 @@
 			"Buffer\\Facebook\\": "Facebook/"
 		}
 	},
-	"version": "1.2.4",
+	"version": "1.2.5",
 	"minimum-stability": "dev"
 }


### PR DESCRIPTION
We should have a new `getPageAccessToken` method to get the page access token. 

https://developers.facebook.com/docs/platforminsights/page

> As of February 5, 2018 all metrics require a page access token of the page of which the insights are being queried. One example is the total number of impressions made by people who saw content associated with your Page. To access such data someone needs to grant you the read_insights permission. Once granted, you can retrieve metrics for all pages owned by this person. If you are not the admin of a Page, you can still read insights about a Page as long as you have a Page Access Token.

