### PR TITLE
Return decoded body from subscribeToWebhook method

### DIFF
--- a/Facebook/Facebook.php
+++ b/Facebook/Facebook.php
@@ -449,7 +449,7 @@ class Facebook
 
     public function subscribeToWebhook($pageId)
     {
-        return $this->sendRequest("POST", "/${pageId}/subscribed_apps");
+        return $this->sendRequest("POST", "/${pageId}/subscribed_apps")->getDecodedBody();
     }
 
     public function getMe()

--- a/tests/FacebookTest.php
+++ b/tests/FacebookTest.php
@@ -978,15 +978,22 @@ class FacebookTest extends PHPUnit_Framework_TestCase
         $facebook = new Facebook();
         $pageId = self::FB_PAGE_ID;
         $facebookMock = m::mock('\Facebook\Facebook');
+
+        $responseMock = m::mock('\Facebook\FacebookResponse')
+        ->shouldReceive('getDecodedBody')
+        ->once()
+        ->andReturn(['success' => true])
+        ->getMock();
+
         $facebookMock
             ->shouldReceive('sendRequest')
             ->once()
             ->with('POST', "/${pageId}/subscribed_apps", [])
-            ->andReturn(true);
+            ->andReturn($responseMock);
         $facebook->setFacebookLibrary($facebookMock);
 
         $response = $facebook->subscribeToWebhook($pageId);
-        $this->assertTrue($response);
+        $this->assertEquals($response, ['success' => true]);
     }
 
     public function testGetInstagramGraphNodeMetadataShouldReturnEmptyIfNoResponse()


### PR DESCRIPTION
According to the [webhook docs](https://developers.facebook.com/docs/instagram-api/webhooks) it the response is:

```
{
  "success": true
}
```