### PR TITLE
remove deprecated fields

### DIFF
--- a/Facebook/Facebook.php
+++ b/Facebook/Facebook.php
@@ -234,7 +234,7 @@ class Facebook
     {
         $since = $since ? $since : strtotime("yesterday");
         $until = $until ? $until : strtotime("now");
-        $fields = 'id,created_time,updated_time,source,attachments,link,message';
+        $fields = 'id,created_time,updated_time,attachments,message';
 
         $response = $this->client->get("/{$pageId}/posts?since={$since}&until={$until}&limit={$limit}&fields={$fields}");
         $rawResponse = json_decode($response->getBody(), true);

--- a/tests/FacebookTest.php
+++ b/tests/FacebookTest.php
@@ -785,7 +785,7 @@ class FacebookTest extends PHPUnit_Framework_TestCase
             "until" => $until,
             "since" => $since,
         ];
-        $expectedGetParams = ["/2222222/posts?since={$since}&until={$until}&limit=100&fields=id,created_time,updated_time,source,attachments,link,message"];
+        $expectedGetParams = ["/2222222/posts?since={$since}&until={$until}&limit=100&fields=id,created_time,updated_time,attachments,message"];
         $facebookMock->shouldReceive('get')->withArgs($expectedGetParams)->once()->andReturn($responseMock);
         $facebook->setFacebookLibrary($facebookMock);
         $facebook->getPagePosts(self::FB_PAGE_ID, $since, $until, 100);


### PR DESCRIPTION
This removes the following fields for posts `source`, and `link`.