### PR TITLE
To fix webhook subscriptions for Instagram Stories

### DIFF
--- a/Facebook/Facebook.php
+++ b/Facebook/Facebook.php
@@ -478,7 +478,12 @@ class Facebook
 
     public function subscribeToWebhook($pageId)
     {
-        return $this->sendRequest("POST", "/${pageId}/subscribed_apps")->getDecodedBody();
+        // With Graph API version 3.2, subscribed_apps requires the subscribed_fields parameter,
+        // which currently does not support Instagram webhooks fields
+        // as a workaround we are subscribing to the email fields, to get the webhooks up and running
+        // so that it will return story_insights events
+        $params = ["subscribed_fields" => 'email' ];
+        return $this->sendRequest("POST", "/${pageId}/subscribed_apps", $params)->getDecodedBody();
     }
 
     public function unsubscribeFromWebhook($pageId)

--- a/tests/FacebookTest.php
+++ b/tests/FacebookTest.php
@@ -984,7 +984,7 @@ class FacebookTest extends PHPUnit_Framework_TestCase
         $facebookMock
             ->shouldReceive('sendRequest')
             ->once()
-            ->with('POST', "/${pageId}/subscribed_apps", [])
+            ->with('POST', "/${pageId}/subscribed_apps", ["subscribed_fields" => 'email' ])
             ->andReturn($responseMock);
         $facebook->setFacebookLibrary($facebookMock);
 


### PR DESCRIPTION
This was introduced by our recent migration to Instagram Graph API v6.

> According to the documentation in https://developers.facebook.com/docs/graph-api/webhooks/getting-started/webhooks-for-instagram> With Graph API version 3.2, the /{page-id}/subscribed_apps edge now requires the subscribed_fields parameter, which currently does not support Instagram webhooks fields. To get around this, use your app's dashboard to subscribe.