### PR TITLE
[EPD-454] Upgrade Facebook Marketing API to version 15

### DIFF
--- a/Facebook/Facebook.php
+++ b/Facebook/Facebook.php
@@ -13,7 +13,7 @@ class Facebook
         $this->client = new FacebookClient([
             'app_id' => getenv('FACEBOOK_APP_ID'),
             'app_secret' => getenv('FACEBOOK_APP_SECRET'),
-            'default_graph_version' => 'v14.0',
+            'default_graph_version' => 'v15.0',
         ]);
     }
 

--- a/Facebook/Facebook.php
+++ b/Facebook/Facebook.php
@@ -13,7 +13,7 @@ class Facebook
         $this->client = new FacebookClient([
             'app_id' => getenv('FACEBOOK_APP_ID'),
             'app_secret' => getenv('FACEBOOK_APP_SECRET'),
-            'default_graph_version' => 'v13.0',
+            'default_graph_version' => 'v14.0',
         ]);
     }
 


### PR DESCRIPTION
This PR updates the Facebook API to version 15. For the Marketing API, version 13 is being deprecated on January 25th, 2023. This brings us to the latest version of the API. 

[Jira ticket (EPD-454)](https://buffer.atlassian.net/browse/EPD-454)