### PR TITLE
Break from user media pagination when return posts out of daterange

### DIFF
--- a/Facebook/Facebook.php
+++ b/Facebook/Facebook.php
@@ -267,6 +267,8 @@ class Facebook
                 $timestamp = strtotime($post->getField("timestamp"));
                 if ($this->isTimestampWitinDateRange($timestamp, $since, $until)) {
                     $posts[] = $post->getField("id");
+                } else {
+                    return $posts;
                 }
             }
             $graphEdge = $this->client->next($graphEdge);

--- a/tests/FacebookTest.php
+++ b/tests/FacebookTest.php
@@ -820,7 +820,6 @@ class FacebookTest extends \PHPUnit\Framework\TestCase
             ->getMock();
         $facebookMock = m::mock('\Facebook\Facebook');
         $facebookMock->shouldReceive('get')->once()->andReturn($responseMock);
-        $facebookMock->shouldReceive('next')->once()->withArgs([$graphEdge])->andReturn(null);
         $facebook->setFacebookLibrary($facebookMock);
 
         $posts = $facebook->getUserMedias(
@@ -878,13 +877,8 @@ class FacebookTest extends \PHPUnit\Framework\TestCase
 
         $since  = "1493826552";
         $until = "1496418552";
-        $params = [
-            "until" => $until,
-            "since" => $since,
-        ];
         $expectedGetParams = ["/55556666/media?fields=timestamp"];
         $facebookMock->shouldReceive('get')->withArgs($expectedGetParams)->once()->andReturn($responseMock);
-        $facebookMock->shouldReceive('next')->withArgs([$graphEdge])->once()->andReturn(null);
         $facebook->setFacebookLibrary($facebookMock);
         $facebook->getUserMedias(self::IG_USER_ID, $since, $until);
     }


### PR DESCRIPTION
We don't seem to stop the user media pagination if the returned posts our falling out of the 