### PR TITLE
Fetch and parse audience broke down metrics

### DIFF
--- a/Facebook/Facebook.php
+++ b/Facebook/Facebook.php
@@ -13,7 +13,7 @@ class Facebook
         $this->client = new FacebookClient([
             'app_id' => getenv('FACEBOOK_APP_ID'),
             'app_secret' => getenv('FACEBOOK_APP_SECRET'),
-            'default_graph_version' => 'v14.0',
+            'default_graph_version' => 'v16.0',
         ]);
     }
 
@@ -104,6 +104,36 @@ class Facebook
             }
         }
 
+
+        return $data;
+    }
+
+    /*
+     * Get the lifetime page insights audience data for the given page.
+     * https://developers.facebook.com/docs/instagram-api/reference/ig-user/insights#metrics
+     */
+    public function getPageInsightsAudienceData($pageId, $metric, $breakdown)
+    {
+        $params = [
+            "metric" => $metric,
+            "breakdown" => $breakdown,
+            "metric_type" => "total_value",
+            "period" => "lifetime",
+        ];
+
+        $data = [];
+        $response = $this->sendRequest("GET", "/{$pageId}/insights", $params);
+
+        if (!empty($response)) {
+            $decodedBody = $response->getDecodedBody();
+
+            if (!empty($decodedBody) && is_array($decodedBody)) {
+                $responseData = $decodedBody["data"];
+                if(!empty($responseData) && isset($responseData[0]["total_value"])) {
+                    $data = $responseData[0]["total_value"]["breakdowns"][0];
+                }
+            }
+        }
 
         return $data;
     }
@@ -390,7 +420,7 @@ class Facebook
             }
         }
         return $result;
-    }
+    }   
 
     /*
      * Make Graph API /insights response to a human readable associative array.

--- a/tests/FacebookTest.php
+++ b/tests/FacebookTest.php
@@ -370,6 +370,82 @@ class FacebookTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals($insightsData["page_fans"]["2017-05-29T07:00:00+0000"], 111);
     }
 
+    public function testGetPageInsightsAudienceData()
+    {
+        $decodedAudienceData = [
+            'data' => [
+                0 => [
+                    'name' => 'follower_demographics',
+                    'period' => 'lifetime',
+                    'total_value' => [
+                        'breakdowns' => [
+                            0 => [
+                                'dimension_keys' => ['city'],
+                                'results' => [
+                                    0 => [
+                                        'dimension_values' => ['Sydney, New South Wales'],
+                                        'value' => 631
+                                    ],
+                                    1 => [
+                                        'dimension_values' => ['London, England'],
+                                        'value' => 1142
+                                    ],
+                                    2 => [
+                                        'dimension_values' => ['Casablanca, Grand Casablanca'],
+                                        'value' => 321
+                                    ],
+                                ]
+                            ]
+                        ],
+                    ],
+                ],
+            ]
+        ];
+
+        $facebook = new Facebook();
+        $responseMock = m::mock('\Facebook\FacebookResponse')
+            ->shouldReceive('getDecodedBody')
+            ->once()
+            ->andReturn($decodedAudienceData)
+            ->getMock();
+        $facebookMock = m::mock('\Facebook\Facebook');
+        $facebookMock->shouldReceive('sendRequest')->once()->andReturn($responseMock);
+        $facebook->setFacebookLibrary($facebookMock);
+
+        $audienceData = $facebook->getPageInsightsAudienceData(
+            self::FB_PAGE_ID,
+            'follower_demographics',
+            'city'
+        );
+
+        $this->assertEquals(['city'], $audienceData['dimension_keys']);
+    }
+
+    public function testGetPageInsightsAudienceDataEmptyResponse()
+    {
+        $decodedAudienceData = [
+            'data' => []
+        ];
+
+        $facebook = new Facebook();
+        $responseMock = m::mock('\Facebook\FacebookResponse')
+        ->shouldReceive('getDecodedBody')
+        ->once()
+            ->andReturn($decodedAudienceData)
+            ->getMock();
+        $facebookMock = m::mock('\Facebook\Facebook');
+        $facebookMock->shouldReceive('sendRequest')->once()->andReturn($responseMock);
+        $facebook->setFacebookLibrary($facebookMock);
+
+        $audienceData = $facebook->getPageInsightsAudienceData(
+            self::FB_PAGE_ID,
+            'follower_demographics',
+            'city'
+        );
+
+        $this->assertEquals([], $audienceData);
+    }
+
     public function testGetPagePostGraphMetricsData()
     {
         $decodedGraphResponseData = [


### PR DESCRIPTION
Facebook API has changed the structure of demographic insights and audience in general. This is a breaking change not only for version 18, but for all previous versions as well. So the existing methods are not helpful. 
This PR introduces a new method that is explicit for audience metrics
https://developers.facebook.com/docs/instagram-api/reference/ig-user/insights#metrics