### PR TITLE
Add method for IG insights navigation metric [chan-361] 

### DIFF
--- a/Facebook/Facebook.php
+++ b/Facebook/Facebook.php
@@ -369,6 +369,33 @@ class Facebook
         return $insights;
     }
 
+    public function getInstagramStoryNavigationInsights($storyId)
+    {
+        $response = $this->sendRequest("GET", "/{$storyId}/insights", [
+            "metric" => "navigation",
+            "breakdown" => "story_navigation_action_type",
+        ]);
+
+        if ($response->isError()) {
+            return null;
+        }
+
+        $data = [];
+
+        if (!empty($response)) {
+            $decodedBody = $response->getDecodedBody();
+
+            if (!empty($decodedBody) && is_array($decodedBody)) {
+                $responseData = $decodedBody["data"];
+                if (!empty($responseData) && isset($responseData[0]["total_value"])) {
+                    $data = $responseData[0]["total_value"]["breakdowns"][0];
+                }
+            }
+        }
+
+        return $data;
+    }
+
     public function getMediaComment($commentId, $fields)
     {
 

--- a/tests/FacebookTest.php
+++ b/tests/FacebookTest.php
@@ -1409,6 +1409,132 @@ class FacebookTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals($response, null);
     }
 
+    public function testGetInstagramStoryNavigationInsightsNullIfError()
+    {
+        $mediaId = '123456789';
+
+        $params = [
+            'metric' => 'navigation',
+            'breakdown' => 'story_navigation_action_type',
+        ];
+
+        $facebook = new Facebook();
+
+        $responseMock = m::mock('\Facebook\FacebookResponse')
+            ->shouldReceive('isError')
+            ->once()
+            ->andReturn(true)
+            ->getMock();
+        $facebookMock = m::mock('\Facebook\Facebook');
+        $facebookMock
+            ->shouldReceive('sendRequest')
+            ->once()
+            ->with('GET', "/${mediaId}/insights", $params)
+            ->andReturn($responseMock);
+        $facebook->setFacebookLibrary($facebookMock);
+
+        $response = $facebook->getInstagramStoryNavigationInsights($mediaId);
+
+        $this->assertEquals($response, null);
+    }
+
+    public function testGetInstagramStoryNavigationInsightsReturnsData()
+    {
+        $mediaId = '123456789';
+
+        $params = [
+            'metric' => 'navigation',
+            'breakdown' => 'story_navigation_action_type',
+        ];
+
+        $facebook = new Facebook();
+
+        $decodedNavigationData = [
+            'data' => [
+                0 => [
+                    'name' => 'navigation',
+                    'period' => 'lifetime',
+                    'total_value' => [
+                        'breakdowns' => [
+                            0 => [
+                                'dimension_keys' => ['story_navigation_action_type'],
+                                'results' => [
+                                    0 => [
+                                        'dimension_values' => ['swipe_forward'],
+                                        'value' => 2
+                                    ],
+                                    1 => [
+                                        'dimension_values' => ['tap_exit'],
+                                        'value' => 20
+                                    ],
+                                    2 => [
+                                        'dimension_values' => ['tap_back'],
+                                        'value' => 4
+                                    ],
+                                    3 => [
+                                        'dimension_values' => ['tap_forward'],
+                                        'value' => 75
+                                    ],
+                                ]
+                            ]
+                        ],
+                    ],
+                ],
+            ]
+        ];
+
+        $responseMock = m::mock('\Facebook\FacebookResponse')
+            ->shouldReceive('isError')
+            ->andReturn(false)
+            ->shouldReceive('getDecodedBody')
+            ->andReturn($decodedNavigationData)
+            ->getMock();
+        $facebookMock = m::mock('\Facebook\Facebook');
+        $facebookMock
+            ->shouldReceive('sendRequest')
+            ->once()
+            ->with('GET', "/${mediaId}/insights", $params)
+            ->andReturn($responseMock);
+        $facebook->setFacebookLibrary($facebookMock);
+
+        $response = $facebook->getInstagramStoryNavigationInsights($mediaId);
+
+        $this->assertEquals($response['results'][0]['dimension_values'][0], 'swipe_forward');
+        $this->assertEquals($response['results'][0]['value'], 2);
+    }
+
+    public function testGetInstagramStoryNavigationInsightsEmptyResponse()
+    {
+        $mediaId = '123456789';
+        $params = [
+            'metric' => 'navigation',
+            'breakdown' => 'story_navigation_action_type',
+        ];
+
+        $facebook = new Facebook();
+        $decodedNavigationData = [
+            'data' => []
+        ];
+
+        $responseMock = m::mock('\Facebook\FacebookResponse')
+        ->shouldReceive('isError')
+        ->andReturn(false)
+            ->shouldReceive('getDecodedBody')
+            ->andReturn($decodedNavigationData)
+            ->getMock();
+        $facebookMock = m::mock('\Facebook\Facebook');
+        $facebookMock
+            ->shouldReceive('sendRequest')
+            ->once()
+            ->with('GET', "/${mediaId}/insights", $params)
+            ->andReturn($responseMock);
+        $facebook->setFacebookLibrary($facebookMock);
+
+        $response = $facebook->getInstagramStoryNavigationInsights($mediaId);
+
+        $this->assertEquals([], $response);
+    }
+
     public function testGetAccountsWorksAsExpected()
     {
         $me = [


### PR DESCRIPTION
Adding a new method for fetching the differently structure navigation metrics from the Instagram stories insights, due to the latest (v18+) backwards breaking changes. 