### PR TITLE
fix: support metric_type for InstagramStoryInsights

### DIFF
--- a/Facebook/Facebook.php
+++ b/Facebook/Facebook.php
@@ -353,13 +353,18 @@ class Facebook
         return $body["data"];
     }
 
-    public function getInstagramStoryInsights($storyId, $metrics)
+    public function getInstagramStoryInsights($storyId, $metrics, $metric_type = null)
     {
         $formattedMetrics = join(",", $metrics);
-
-        $response = $this->sendRequest("GET", "/{$storyId}/insights", [
+        $params = [
             "metric" => $formattedMetrics,
-        ]);
+        ];
+
+        if (!is_null($metric_type)) {
+            $params["metric_type"] = $metric_type;
+        }
+
+        $response = $this->sendRequest("GET", "/{$storyId}/insights", $params);
 
         if ($response->isError()) {
             return null;

--- a/tests/FacebookTest.php
+++ b/tests/FacebookTest.php
@@ -1357,19 +1357,14 @@ class FacebookTest extends \PHPUnit\Framework\TestCase
 
         $facebook = new Facebook();
 
-        $responseMock = m::mock('\Facebook\FacebookResponse')
-            ->shouldReceive('isError')
-            ->once()
-            ->andReturn(false)
-            ->shouldReceive('getDecodedBody')
-            ->once()
-            ->andReturn($decodedInsightsResponseData)
-            ->getMock();
+        $responseMock = m::mock('\Facebook\FacebookResponse');
+        $responseMock->shouldReceive('isError')->once()->andReturn(false);
+        $responseMock->shouldReceive('getDecodedBody')->once()->andReturn($decodedInsightsResponseData);
+
         $facebookMock = m::mock('\Facebook\Facebook');
-        $facebookMock
-            ->shouldReceive('sendRequest')
+        $facebookMock->shouldReceive('sendRequest')
             ->once()
-            ->with('GET', "/${mediaId}/insights", ["metric" => $metrics])
+            ->with('GET', '/' . $mediaId . '/insights', ["metric" => $metrics])
             ->andReturn($responseMock);
         $facebook->setFacebookLibrary($facebookMock);
 
@@ -1400,7 +1395,7 @@ class FacebookTest extends \PHPUnit\Framework\TestCase
         $facebookMock
             ->shouldReceive('sendRequest')
             ->once()
-            ->with('GET', "/${mediaId}/insights", ["metric" => $metrics])
+            ->with('GET', '/' . $mediaId . '/insights', ["metric" => $metrics])
             ->andReturn($responseMock);
         $facebook->setFacebookLibrary($facebookMock);
 
@@ -1429,7 +1424,7 @@ class FacebookTest extends \PHPUnit\Framework\TestCase
         $facebookMock
             ->shouldReceive('sendRequest')
             ->once()
-            ->with('GET', "/${mediaId}/insights", $params)
+            ->with('GET', '/' . $mediaId . '/insights', $params)
             ->andReturn($responseMock);
         $facebook->setFacebookLibrary($facebookMock);
 
@@ -1493,7 +1488,7 @@ class FacebookTest extends \PHPUnit\Framework\TestCase
         $facebookMock
             ->shouldReceive('sendRequest')
             ->once()
-            ->with('GET', "/${mediaId}/insights", $params)
+            ->with('GET', '/' . $mediaId . '/insights', $params)
             ->andReturn($responseMock);
         $facebook->setFacebookLibrary($facebookMock);
 
@@ -1526,7 +1521,7 @@ class FacebookTest extends \PHPUnit\Framework\TestCase
         $facebookMock
             ->shouldReceive('sendRequest')
             ->once()
-            ->with('GET', "/${mediaId}/insights", $params)
+            ->with('GET', '/' . $mediaId . '/insights', $params)
             ->andReturn($responseMock);
         $facebook->setFacebookLibrary($facebookMock);
 
@@ -1663,5 +1658,55 @@ class FacebookTest extends \PHPUnit\Framework\TestCase
         $response = $facebook->getTokenScopes($inputToken);
 
         $this->assertEquals(['email', 'public_profile'], $response['data']['scopes']);
+    }
+
+    public function testGetInstagramStoryInsightsWithMetricType()
+    {
+        $mediaId = "123456789";
+        $decodedInsightsResponseData = [
+            'data' => [
+                [
+                    'name' => 'reach',
+                    'period' => 'lifetime',
+                    'values' => [
+                        [
+                            'value' => 123,
+                        ],
+                    ],
+                ],
+                [
+                    'name' => 'views',
+                    'period' => 'lifetime',
+                    'values' => [
+                        [
+                            'value' => 500,
+                        ],
+                    ],
+                ],
+            ]
+        ];
+
+        $metricsArray = ['reach', 'views'];
+        $metrics = join(",", $metricsArray);
+
+        $facebook = new Facebook();
+
+        $responseMock = m::mock('\Facebook\FacebookResponse');
+        $responseMock->shouldReceive('isError')->once()->andReturn(false);
+        $responseMock->shouldReceive('getDecodedBody')->once()->andReturn($decodedInsightsResponseData);
+
+        $facebookMock = m::mock('\Facebook\Facebook');
+        $facebookMock->shouldReceive('sendRequest')
+            ->once()
+            ->with('GET', '/' . $mediaId . '/insights', ["metric" => $metrics, "metric_type" => "total_values"])
+            ->andReturn($responseMock);
+        $facebook->setFacebookLibrary($facebookMock);
+
+        $response = $facebook->getInstagramStoryInsights($mediaId, $metricsArray, "total_values");
+
+        $this->assertEquals($response, [
+            'reach' => 123,
+            'views' => 500
+        ]);
     }
 }


### PR DESCRIPTION
Adds support for the `metric_type` parameter, which is required when the metrics `views` is requested. 
`views` is replacing `impressions` for the Instagram media from version 22.0 and backwards to all versions from April 21st, 2025.