### PR TITLE
Support metric_type option which is necessary for the views metric

### DIFF
--- a/Facebook/Facebook.php
+++ b/Facebook/Facebook.php
@@ -230,17 +230,22 @@ class Facebook
     /*
      * Get page batch posts insights data for the given posts and metrics.
      */
-    public function getPageBatchPostsInsightsMetricData($postIds, $insightsMetrics)
+    public function getPageBatchPostsInsightsMetricData($postIds, $insightsMetrics, $metric_type = null)
     {
         $result = [];
         $batchRequests = [];
         $insightsMetricsString = join(",", $insightsMetrics);
+        $params = [
+            "metric" => $insightsMetricsString,
+            "period" => "lifetime",
+            "until" => strtotime("now"),
+        ];
+
+        if (!is_null($metric_type)) {
+            $params["metric_type"] = $metric_type;
+        }
         foreach ($postIds as $postId) {
-            $request = $this->createRequest("GET", "/{$postId}/insights", [
-                "metric" => $insightsMetricsString,
-                "period" => "lifetime",
-                "until" => strtotime("now"),
-            ]);
+            $request = $this->createRequest("GET", "/{$postId}/insights", $params);
             $batchRequests[$postId] = $request;
         }
 


### PR DESCRIPTION
Expands to support the parameter `metric_type`, which is required for fetching the Instagram `views` metric. 